### PR TITLE
Update target frameworks and copyright years

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-2025
+    runs-on: windows-latest
     outputs:
       nbgv: ${{ steps.nbgv.outputs.SemVer2 }}
     steps:
@@ -23,13 +23,12 @@ jobs:
         fetch-depth: 0
         lfs: true
         
-    - name: Install .NET 6 / 7 / 8
+    - name: Install .NET 8 and 9
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
 
     - name: NBGV
       id: nbgv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,12 @@ jobs:
         fetch-depth: 0
         lfs: true
         
-    - name: Install .NET 6 / 7 / 8
+    - name: Install .NET 8 and 9
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
         
     - name: NBGV
       id: nbgv

--- a/src/ReactiveMarbles.CacheData.SystemTextJson/ReactiveMarbles.CacheDatabase.SystemTextJson.csproj
+++ b/src/ReactiveMarbles.CacheData.SystemTextJson/ReactiveMarbles.CacheDatabase.SystemTextJson.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>

--- a/src/ReactiveMarbles.CacheData.SystemTextJson/SystemJsonSerializer.cs
+++ b/src/ReactiveMarbles.CacheData.SystemTextJson/SystemJsonSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Benchmarks/ReactiveMarbles.CacheDatabase.Benchmarks.csproj
+++ b/src/ReactiveMarbles.CacheDatabase.Benchmarks/ReactiveMarbles.CacheDatabase.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/ReactiveMarbles.CacheDatabase.Core/CoreRegistrations.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Core/CoreRegistrations.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Core/HttpExtensions.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Core/HttpExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Core/HttpService.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Core/HttpService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Core/IBlobCache.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Core/IBlobCache.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Core/IHttpService.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Core/IHttpService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Core/ISecureBlobCache.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Core/ISecureBlobCache.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Core/ISerializer.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Core/ISerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Core/LoginExtensions.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Core/LoginExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Core/LoginInfo.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Core/LoginInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Core/PreserveAttribute.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Core/PreserveAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Core/Properties/AssemblyInfo.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Core/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Core/ReactiveMarbles.CacheDatabase.Core.csproj
+++ b/src/ReactiveMarbles.CacheDatabase.Core/ReactiveMarbles.CacheDatabase.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>

--- a/src/ReactiveMarbles.CacheDatabase.Core/RelativeTimeExtensions.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Core/RelativeTimeExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Core/SerializerExtensions.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Core/SerializerExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.EncryptedSettings.Tests/ReactiveMarbles.CacheDatabase.EncryptedSettings.Tests.csproj
+++ b/src/ReactiveMarbles.CacheDatabase.EncryptedSettings.Tests/ReactiveMarbles.CacheDatabase.EncryptedSettings.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/ReactiveMarbles.CacheDatabase.EncryptedSettings.Tests/SettingsCacheTests.cs
+++ b/src/ReactiveMarbles.CacheDatabase.EncryptedSettings.Tests/SettingsCacheTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.EncryptedSettings.Tests/Usings.cs
+++ b/src/ReactiveMarbles.CacheDatabase.EncryptedSettings.Tests/Usings.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.EncryptedSettings/ReactiveMarbles.CacheDatabase.EncryptedSettings.csproj
+++ b/src/ReactiveMarbles.CacheDatabase.EncryptedSettings/ReactiveMarbles.CacheDatabase.EncryptedSettings.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>ReactiveMarbles.CacheDatabase.EncryptedSettings</RootNamespace>

--- a/src/ReactiveMarbles.CacheDatabase.EncryptedSqlite3/ReactiveMarbles.CacheDatabase.EncryptedSqlite3.csproj
+++ b/src/ReactiveMarbles.CacheDatabase.EncryptedSqlite3/ReactiveMarbles.CacheDatabase.EncryptedSqlite3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
     <DefineConstants>$(DefineConstants);ENCRYPTED</DefineConstants>

--- a/src/ReactiveMarbles.CacheDatabase.NewtonsoftJson/NewtonsoftSerializer.cs
+++ b/src/ReactiveMarbles.CacheDatabase.NewtonsoftJson/NewtonsoftSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.NewtonsoftJson/ReactiveMarbles.CacheDatabase.NewtonsoftJson.csproj
+++ b/src/ReactiveMarbles.CacheDatabase.NewtonsoftJson/ReactiveMarbles.CacheDatabase.NewtonsoftJson.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>

--- a/src/ReactiveMarbles.CacheDatabase.Settings.Tests/Mocks/EnumTestValue.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Settings.Tests/Mocks/EnumTestValue.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Settings.Tests/Mocks/ViewSettings.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Settings.Tests/Mocks/ViewSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Settings.Tests/ReactiveMarbles.CacheDatabase.Settings.Tests.csproj
+++ b/src/ReactiveMarbles.CacheDatabase.Settings.Tests/ReactiveMarbles.CacheDatabase.Settings.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/ReactiveMarbles.CacheDatabase.Settings.Tests/SettingsCacheTests.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Settings.Tests/SettingsCacheTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Settings.Tests/Usings.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Settings.Tests/Usings.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Settings/Core/AppInfo.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Settings/Core/AppInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Settings/Core/ISettingsStorage.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Settings/Core/ISettingsStorage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Settings/Core/SettingsStorage.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Settings/Core/SettingsStorage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Settings/ReactiveMarbles.CacheDatabase.Settings.csproj
+++ b/src/ReactiveMarbles.CacheDatabase.Settings/ReactiveMarbles.CacheDatabase.Settings.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>ReactiveMarbles.CacheDatabase.Settings</RootNamespace>

--- a/src/ReactiveMarbles.CacheDatabase.Settings/SettingsBase.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Settings/SettingsBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Sqlite3/CacheEntry.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Sqlite3/CacheEntry.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Sqlite3/ReactiveMarbles.CacheDatabase.Sqlite3.csproj
+++ b/src/ReactiveMarbles.CacheDatabase.Sqlite3/ReactiveMarbles.CacheDatabase.Sqlite3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>

--- a/src/ReactiveMarbles.CacheDatabase.Sqlite3/SqliteBlobCache.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Sqlite3/SqliteBlobCache.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Tests/BlobCacheTestsBase.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Tests/BlobCacheTestsBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Tests/EncryptedSqliteBlobCacheTests.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Tests/EncryptedSqliteBlobCacheTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Tests/Helpers/IntegrationTestHelper.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Tests/Helpers/IntegrationTestHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Tests/Helpers/Utility.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Tests/Helpers/Utility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Tests/Mocks/UserModel.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Tests/Mocks/UserModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Tests/Mocks/UserObject.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Tests/Mocks/UserObject.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/ReactiveMarbles.CacheDatabase.Tests/ReactiveMarbles.CacheDatabase.Tests.csproj
+++ b/src/ReactiveMarbles.CacheDatabase.Tests/ReactiveMarbles.CacheDatabase.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/ReactiveMarbles.CacheDatabase.Tests/SqliteBlobCacheTests.cs
+++ b/src/ReactiveMarbles.CacheDatabase.Tests/SqliteBlobCacheTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2019-2022 ReactiveUI Association Incorporated. All rights reserved.
+﻿// Copyright (c) 2019-2025 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 

--- a/src/stylecop.json
+++ b/src/stylecop.json
@@ -13,7 +13,7 @@
             "documentPrivateFields": false,
             "documentationCulture": "en-US",
             "companyName": "ReactiveUI Association Incorporated",
-            "copyrightText": "Copyright (c) 2019-2022 {companyName}. All rights reserved.\n{companyName} licenses this file to you under the {licenseName} license.\nSee the {licenseFile} file in the project root for full license information.",
+            "copyrightText": "Copyright (c) 2019-2025 {companyName}. All rights reserved.\n{companyName} licenses this file to you under the {licenseName} license.\nSee the {licenseFile} file in the project root for full license information.",
             "variables": {
                 "licenseName": "MIT",
                 "licenseFile": "LICENSE"


### PR DESCRIPTION
Bump supported target frameworks to net8.0 and net9.0, removing net6.0 and net7.0 where applicable, across all projects and tests. Update copyright years from 2019-2022 to 2019-2025 in all source files and StyleCop configuration.